### PR TITLE
Update product-gallery.js

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/web/js/product-gallery.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/product-gallery.js
@@ -456,7 +456,7 @@ define([
             events['click ' + this.options.imageSelector] = function (event) {
                 var imageData, $imageContainer;
 
-                if (!$(event.currentTarget).is('.ui-sortable-helper')) {
+                if (!$(event.currentTarget).is('.ui-sortable-helper') && dragging == false) {
                     $(event.currentTarget).addClass('active');
                     imageData = $(event.currentTarget).data('imageData');
                     $imageContainer = this.findElement(imageData);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR aims to solve this Product Media Gallery Drag and Drop Issue in Firefox
Now Modal Popup open only when clicking on Image Item as before Popup open when drag and drop Image item in Firefox


### Related Pull Requests
<!-- related pull request placeholder -->
https://github.com/magento/magento2/issues/29175

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes #29175

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. I have tested this in Firefox
2. I have also tested it in other Browser

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
